### PR TITLE
Send only last output to stdout

### DIFF
--- a/jupyter_spaces/space.py
+++ b/jupyter_spaces/space.py
@@ -104,15 +104,16 @@ class Space:
             source (str): Source code.
         """
         tree = ast.parse(source=source)
+        self._execute(body=tree.body[:-1], mode="exec")
+        self._execute(body=tree.body[-1:], mode="single")
 
-        interactive_tree = ast.Interactive(body=tree.body)
+    def _execute(self, body, mode):
+        tree_types = {"exec": ast.Module, "single": ast.Interactive}
+        tree = tree_types[mode](body=body)
         if sys.version_info > (3, 8):
-            interactive_tree.type_ignores = tree.type_ignores
-
-        compiled_interactive_tree = compile(
-            source=interactive_tree, filename="<string>", mode="single"
-        )
-        exec(compiled_interactive_tree, self._execution_namespace)
+            tree.type_ignores = []
+        code = compile(source=tree, filename="<string>", mode=mode)
+        exec(code, self._execution_namespace)
 
 
 class _ChainNamespace(ChainMap, dict):

--- a/tests/test_magics.py
+++ b/tests/test_magics.py
@@ -65,6 +65,10 @@ def test_space_reference_deletions_persist_in_new_magic_call(ip):
         ip.run_cell_magic(magic_name="space", line="tomato", cell="x")
 
 
+def test_space_reference_assignments_persist_in_same_magic_call(ip):
+    ip.run_cell_magic(magic_name="space", line="tomato", cell="x = 1; y = x + 1")
+
+
 def test_space_references_assignments_are_confined_in_one_space_only(ip):
     ip.run_cell_magic(magic_name="space", line="tomato", cell="x = 99")
     ip.run_cell_magic(magic_name="space", line="potato", cell="x = 100")
@@ -151,11 +155,26 @@ def test_get_spaces_reflects_extension_reload(ip):
     assert not ip.user_global_ns["spaces"]
 
 
-def test_space_outputs_to_console(ip, capsys):
+def test_last_output_is_sent_to_stdout(ip, capsys):
     ip.run_cell_magic(magic_name="space", line="tomato", cell="100")
     assert capsys.readouterr().out == "100\n"
 
 
-def test_space_can_print_to_console(ip, capsys):
+def test_only_last_output_is_sent_to_stdout(ip, capsys):
+    ip.run_cell_magic(magic_name="space", line="tomato", cell="1\n2")
+    assert capsys.readouterr().out == "2\n"
+
+
+def test_space_can_print_to_stdout(ip, capsys):
     ip.run_cell_magic(magic_name="space", line="tomato", cell="print(100)")
     assert capsys.readouterr().out == "100\n"
+
+
+def test_none_does_not_produce_any_stdout(ip, capsys):
+    ip.run_cell_magic(magic_name="space", line="tomato", cell="None")
+    assert capsys.readouterr().out == ""
+
+
+def test_statement_does_not_produce_any_stdout(ip, capsys):
+    ip.run_cell_magic(magic_name="space", line="tomato", cell="x = 1")
+    assert capsys.readouterr().out == ""

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -95,6 +95,31 @@ class TestSpace:
         space.namespace["y"] = 1
         assert repr(space) == "Space(name=tomato, size=2)"
 
+    def test_last_output_is_sent_to_stdout(self, capsys):
+        space = Space(name="tomato", outer_space={})
+        space.execute(source="1")
+        assert capsys.readouterr().out == "1\n"
+
+    def test_only_last_output_is_sent_to_stdout(self, capsys):
+        space = Space(name="tomato", outer_space={})
+        space.execute(source="1\n2")
+        assert capsys.readouterr().out == "2\n"
+
+    def test_none_does_not_produce_any_stdout(self, capsys):
+        space = Space(name="tomato", outer_space={})
+        space.execute(source="None")
+        assert capsys.readouterr().out == ""
+
+    def test_statement_does_not_produce_any_stdout(self, capsys):
+        space = Space(name="tomato", outer_space={})
+        space.execute(source="x = 1")
+        assert capsys.readouterr().out == ""
+
+    def test_use_variable_defined_in_same_source(self):
+        space = Space(name="tomato", outer_space={})
+        space.execute(source="x = 1; y = x + 1")
+        assert space.namespace == {"x": 1, "y": 2}
+
 
 class TestSpaceRegister:
     def test_get_new_space(self):


### PR DESCRIPTION
This PR fixes a regression bug introduced in version `0.2.0` when trying to automatically render the last cell result. Instead of having just the last output sent to stdout, all cell outputs were.

Closes issue #24.